### PR TITLE
[BUGFIX] Stop using GeneralUtility::requireOnce

### DIFF
--- a/Classes/Utility/EmogrifierUtility.php
+++ b/Classes/Utility/EmogrifierUtility.php
@@ -14,7 +14,6 @@ namespace WebentwicklerAt\Emogrifier\Utility;
  */
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class EmogrifierUtility
 {
@@ -32,7 +31,7 @@ class EmogrifierUtility
                     'emogrifier',
                     'Resources/Private/Php/Emogrifier.phar/vendor/autoload.php'
                 );
-                GeneralUtility::requireOnce('phar://' . $pharPath);
+                require_once 'phar://' . $pharPath;
             }
             $emogrifier = new \Pelago\Emogrifier($content, $css);
             $content = $emogrifier->emogrify();


### PR DESCRIPTION
This method has been deprecated in TYPO3 8.7.